### PR TITLE
Increase token scope from `public_repo` to `repo`

### DIFF
--- a/public/js/gpgc_core.js
+++ b/public/js/gpgc_core.js
@@ -220,7 +220,7 @@ function loginToGitHub() {
   StateChallenge = challengeArray[0].toString() + challengeArray[1].toString();
   var data = {
     "client_id": gpgc.github_application_client_id,
-    "scope": "public_repo",
+    "scope": "repo",
     "state": StateChallenge,
     "redirect_uri": gpgc.github_application_login_redirect_url
   };


### PR DESCRIPTION
Attempt to fix [Issue 32](https://github.com/wireddown/ghpages-ghcomments/issues/32) in `ghpages-ghcomments`.

GitHub documentation that confirms this scope is appropriate for OAuth apps: https://developer.github.com/apps/building-integrations/setting-up-a-new-integration/about-choosing-an-integration-type/#requesting-permission-levels-for-resources-of-integrations